### PR TITLE
Add ios to platforms

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,7 +12,7 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   String _timezone = 'Unknown';
-  List<String> _availableTimezones = List<String>();
+  List<String> _availableTimezones = <String>[];
 
   @override
   void initState() {

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -11,7 +11,8 @@ void main() {
     expect(
       find.byWidgetPredicate(
         (Widget widget) =>
-            widget is Text && widget.data.startsWith('Local timezone:'),
+            widget is Text &&
+            widget.data?.startsWith('Local timezone:') == true,
       ),
       findsOneWidget,
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -144,3 +144,4 @@ packages:
     version: "2.1.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"
+  flutter: ">=1.12.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,5 +23,7 @@ flutter:
       android:
         package: com.whelksoft.flutter_native_timezone
         pluginClass: FlutterNativeTimezonePlugin
+      ios:
+        pluginClass: FlutterNativeTimezonePlugin
       macos:
         pluginClass: FlutterNativeTimezonePlugin


### PR DESCRIPTION
Since the last version iOS doesn't work any more. This PR fixes it.

https://github.com/pinkfish/flutter_native_timezone/issues/9#issuecomment-790959357

There have been two errors in the package. Fixed them, so the tests pass.