### PR TITLE
Upgrade kotlin_version to support newer Gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.whelksoft.flutter_native_timezone'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.3.40'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
Fixes build error: The Android Gradle plugin supports only Kotlin Gradle plugin version 1.3.40 and higher.