### PR TITLE
minSDkVersion set to 26 because ->  https://developer.android.com/ref…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.2
+Android minSdkVersion bumped to 26
 ## 2.0.1
 
 Improve pub.dev score

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ android {
     }
     defaultConfig {
         targetSdkVersion 30
-        minSdkVersion 16
+        minSdkVersion 26
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_native_timezone
 description: A flutter plugin for getting the local timezone of the device.
-version: 2.0.1
+version: 2.0.2
 homepage: https://github.com/pinkfish/flutter_native_timezone
 
 environment:


### PR DESCRIPTION
Hello @pinkfish,

I have bumped the minSdkVersion to 26 as this plugin imports `'import java.time.ZoneId'` which was introduced in API level 26.
For reference Link to Android documentation: [Android documentation link](https://developer.android.com/reference/java/time/ZoneId)
link to Code where above is imported: [Code Link](https://github.com/pinkfish/flutter_native_timezone/blob/ce3f3d21ea01a0b60195a301bc9a9715943a7c62/android/src/main/kotlin/com/whelksoft/flutter_native_timezone/FlutterNativeTimezonePlugin.kt#L7)

Also please note this is not a new issue, I see from open && closed issues effort was made in trying to close this matter.  [#issue28](https://github.com/pinkfish/flutter_native_timezone/issues/28)