### PR TITLE
Update JVM target compatibility and bump version to 2.1.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.whelksoft.flutter_native_timezone'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.5.30'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         mavenCentral()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,3 @@
-group 'com.whelksoft.flutter_native_timezone'
-version '1.0-SNAPSHOT'
-
 buildscript {
     ext.kotlin_version = '1.9.10'
     repositories {
@@ -29,21 +26,13 @@ android {
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
-    defaultConfig {
-        targetSdkVersion 30
-        minSdkVersion 16
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-    }
-    lintOptions {
-        disable 'InvalidPackage'
-    }
-}
 
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-}
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,11 +28,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'com.android.tools.build:gradle:8.3.1'
     }
 }
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.whelksoft.flutter_native_timezone">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    namespace "com.whelksoft.flutter_native_timezone"
+>
 </manifest>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_native_timezone
 description: A flutter plugin for getting the local timezone of the device.
-version: 2.1.1
+version: 2.2.0
 homepage: https://github.com/pinkfish/flutter_native_timezone
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_native_timezone
 description: A flutter plugin for getting the local timezone of the device.
-version: 2.0.1
+version: 2.1.0
 homepage: https://github.com/pinkfish/flutter_native_timezone
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_native_timezone
 description: A flutter plugin for getting the local timezone of the device.
-version: 2.1.0
+version: 2.1.1
 homepage: https://github.com/pinkfish/flutter_native_timezone
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_native_timezone
 description: A flutter plugin for getting the local timezone of the device.
-version: 2.2.1
+version: 2.2.2
 homepage: https://github.com/pinkfish/flutter_native_timezone
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_native_timezone
 description: A flutter plugin for getting the local timezone of the device.
-version: 2.2.0
+version: 2.2.1
 homepage: https://github.com/pinkfish/flutter_native_timezone
 
 environment:


### PR DESCRIPTION
This PR includes the following changes:

Android: Updated JVM target compatibility to ensure consistent Java and Kotlin compilation.
Set [sourceCompatibility](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) and [targetCompatibility](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) to Java 17.
Configured [kotlinOptions](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) to use JVM target 17.
Updated Kotlin version to 1.9.10.
Version Bump: Updated the package version to 2.1.0 in [pubspec.yaml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html).
This pull request includes several updates to the `flutter_native_timezone` plugin, focusing on upgrading dependencies and improving compatibility with newer versions of Java and Kotlin.

Dependency and Compatibility Upgrades:

* [`android/build.gradle`](diffhunk://#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65aL1-R2): Upgraded Kotlin version from `1.5.30` to `1.9.10` to ensure compatibility with newer features and improvements.
* [`android/build.gradle`](diffhunk://#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65aL32-R37): Updated `compileOptions` and `kotlinOptions` to use Java 17, improving compatibility with the latest Java version.

Version Bump:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L3-R3): Increased the plugin version from `2.0.1` to `2.1.0` to reflect the updates and improvements made.